### PR TITLE
Fixed song directories being misnamed.

### DIFF
--- a/EnhancedTwitchIntegration/Bot/util.cs
+++ b/EnhancedTwitchIntegration/Bot/util.cs
@@ -153,8 +153,6 @@ namespace SongRequestManager
                 _SymbolsValidDirectory[';'] = '\0';
                 _SymbolsValidDirectory['$'] = '\0';
                 _SymbolsValidDirectory['.'] = '\0';
-                _SymbolsValidDirectory['('] = '\0';
-                _SymbolsValidDirectory[')'] = '\0';
 
                 // Incomplete list of words that BeatSaver.com filters out for no good reason. No longer applies!
                 foreach (var word in new string[] { "pp" })


### PR DESCRIPTION
Parenthesis are valid directory characters, and part of the naming convention for song folders.