### PR TITLE
Add SongCore as a dependency in manifest.json

### DIFF
--- a/EnhancedTwitchIntegration/manifest.json
+++ b/EnhancedTwitchIntegration/manifest.json
@@ -11,6 +11,6 @@
     "BeatSaberMarkupLanguage": "^1.5.1",
     "BS Utils": "^1.8.0",
     "ChatCore": "^2.0.0",
-	"SongCore": "^3.0.0"
+    "SongCore": "^3.0.0"
   }
 }

--- a/EnhancedTwitchIntegration/manifest.json
+++ b/EnhancedTwitchIntegration/manifest.json
@@ -10,6 +10,7 @@
     "BSIPA": "^4.1.4",
     "BeatSaberMarkupLanguage": "^1.5.1",
     "BS Utils": "^1.8.0",
-    "ChatCore": "^2.0.0"
+    "ChatCore": "^2.0.0",
+	"SongCore": "^3.0.0"
   }
 }


### PR DESCRIPTION
SRM requires SongCore in order to work. If SongCore is missing, SRM crashes the game when entering the SRM menu in the song selection menu. As such, SongCore should be listed as a dependency in the manifest.