### PR TITLE
Remove !sr alias

### DIFF
--- a/EnhancedTwitchIntegration/Bot/commands.cs
+++ b/EnhancedTwitchIntegration/Bot/commands.cs
@@ -121,7 +121,7 @@ namespace SongRequestManager
             */
 
 
-            new COMMAND(new string[] { "!request", "!bsr", "!add", "!sr","!srm" }).Action(ProcessSongRequest).Help(Everyone, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the request queue. Try and be a little specific. You can look up songs on %beatsaver%", _atleast1);
+            new COMMAND(new string[] { "!request", "!bsr", "!add","!srm" }).Action(ProcessSongRequest).Help(Everyone, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the request queue. Try and be a little specific. You can look up songs on %beatsaver%", _atleast1);
             new COMMAND(new string[] { "!lookup", "!find" }).AsyncAction(LookupSongs).Help(Mod | Sub | VIP, "usage: %alias%<song name> or <song id>, omit <>'s.%|%Get a list of songs from %beatsaver% matching your search criteria.", _atleast1);
 
             new COMMAND("!link").Action(ShowSongLink).Help(Everyone, "usage: %alias% %|%... Shows song details, and an %beatsaver% link to the current song", _nothing);


### PR DESCRIPTION
I decided to use !sr as the main command for requesting songs with my [Shaffuru Mod](https://github.com/kinsi55/BeatSaber_Shaffuru#shaffuru) so its as easy as removing the b from !bsr - However wasnt aware that SRM also listens for !sr. I dont think I ever saw anyone request a song using !sr so it would be great if removing the alias from SRM could be considered.